### PR TITLE
Fix some compile issues

### DIFF
--- a/tactile-control-lib/src/TactileControl/src/task/ControlTask.cpp
+++ b/tactile-control-lib/src/TactileControl/src/task/ControlTask.cpp
@@ -94,7 +94,7 @@ void ControlTask::init(){
     for(int i = 0; i < forceTargetValue.size(); i++){
         logStream << forceTargetValue[i] << " ";
     }
-    yInfo() << logStream;
+    yInfo() << logStream.str();
 }
 
 void ControlTask::initLowLevelPID(){

--- a/tactile-control-lib/src/TactileControl/src/task/StepTask.cpp
+++ b/tactile-control-lib/src/TactileControl/src/task/StepTask.cpp
@@ -30,7 +30,7 @@ void StepTask::init(){
         for(int i = 0; i < constantPwm.size(); i++){
             logStream << constantPwm[i] << " ";
         }
-        yInfo() << logStream;
+        yInfo() << logStream.str();
     }
 
 }

--- a/tactile-control-lib/src/TactileControl/src/task/StepTask.cpp
+++ b/tactile-control-lib/src/TactileControl/src/task/StepTask.cpp
@@ -4,6 +4,8 @@
 
 #include <sstream>
 
+#include <yarp/os/LogStream.h>
+
 using tactileControl::StepTask;
 
 

--- a/tactile-control-lib/src/TactileControl/src/util/PortUtil.cpp
+++ b/tactile-control-lib/src/TactileControl/src/util/PortUtil.cpp
@@ -3,6 +3,7 @@
 #include "TactileControl/data/Parameters.h"
 
 #include <yarp/os/Network.h>
+#include <yarp/os/LogStream.h>
 
 using tactileControl::PortUtil;
 using std::string;


### PR DESCRIPTION
Multiple issues were encountered regarding the usage of yarp::os::LogStream:

- Some files were using LogStream, while they did not include its header
- Some files tried to stream an std::stringstream into a yInfo() (which is a macro that constructs a Log I think). I guess the intention was to stream the string contained by the stringstream instead of the stringstream itself, so I fixed that.

The issues were encountered when compiling against yarp 2.3.70. This PR should fix both issues.